### PR TITLE
remove deprecated cmo id extraction from lims-igo endpoint

### DIFF
--- a/sample-tracking-api/app/app.py
+++ b/sample-tracking-api/app/app.py
@@ -298,8 +298,6 @@ def update_record(record, item):
         record.scientific_pi = item.get('scientificPi')
         record.source_dna_type = item.get('sourceDnaType')
         record.data_custodian = item.get("dataCustodian")
-        record.tempo_output_delivery_date = item.get("tempoOutputDeliveryDate")
-        record.embargo_end_date = calculate_outdate(record.tempo_output_delivery_date)
         record.date_updated = str(datetime.datetime.now())
         record.updated_by = 'api'
         db.session.commit()
@@ -332,10 +330,6 @@ def update_record(record, item):
         if sampledata is not None:
             sampledata.sampleid = item.get('sampleId')
             sampledata.alt_id = item.get('altId')
-            cmo_sampleid = item.get('cmoSampleId',None)
-            cmo_patientid = item.get('cmoPatientId',None)
-            sampledata.cmo_sampleid = cmo_sampleid if cmo_sampleid else sampledata.get("cmo_sampleid","")
-            sampledata.cmo_patientid = cmo_patientid if cmo_patientid else sampledata.get("cmo_patientid","")
             sampledata.parental_tumortype = item.get('parentalTumorType')
             sampledata.collection_year = item.get('collectionYear')
             sampledata.igo_requestid = item.get('igoRequestId')


### PR DESCRIPTION
In #30, an api command was added to accept cmo id values from sources other than the lims, but lims values were still being accepted. As CMO IDs are now being officially deprecated from the LIMS endpoint, this PR will remove any special handling of CMO IDs from that endpoint and that info will be maintained by the new api call `/update_cmo_id`.

Additionally, `tempo_output_delivery_date` and `embargo_end_date` will no longer be updated by the LIMS endpoint to avoid confusion about information from desynced endpoints (the hera database and the dmp tracker). 