### PR TITLE
Add missing frontend python script to repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ sample-tracking-api/env/
 sample-tracking-frontend/.gitignore
 sample-tracking-frontend/README.md
 sample-tracking-frontend/public/
-sample-tracking-frontend/sample-tracking-frontend.py
 sample-tracking-frontend/src/index.css
 sample-tracking-frontend/src/serviceWorker.js
 sample-tracking-api/database/__pycache__/models.cpython-37.pyc

--- a/sample-tracking-frontend/sample-tracking-frontend.py
+++ b/sample-tracking-frontend/sample-tracking-frontend.py
@@ -1,0 +1,17 @@
+import os
+from flask import Flask, send_from_directory
+
+app = Flask(__name__, static_folder='./build')
+
+# Serve React App
+@app.route('/', defaults={'path': ''})
+@app.route('/<path:path>')
+def serve(path):
+    if path != "" and os.path.exists(app.static_folder + '/' + path):
+        return send_from_directory(app.static_folder, path)
+    else:
+        return send_from_directory(app.static_folder, 'index.html')
+
+
+if __name__ == '__main__':
+    app.run()


### PR DESCRIPTION
Added file necessary for frontend uwsgi serving, and removed the path from the .gitignore because it has no secret information. 

The `wsgi-file` parameter should point to the `sample-tracking-frontend/sample-tracking-frontend.py` file in the deploy folder.

It's useful to have this file in the repo so we can more easily rebuild the frontend tracker from scratch by pulling down the github folder. 